### PR TITLE
Fix 'Could not find executable unittests'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(unittests PRIVATE
         cbor_parser
         CONAN_PKG::jsoncpp)
 
-add_test(unittests ${PROJECT_BINARY_DIR}/unittests)
+add_test(unittests ${PROJECT_BINARY_DIR}/bin/unittests)
 set_tests_properties(unittests PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
 ###############################################################


### PR DESCRIPTION
I had this issue : 
```
test 1
    Start 1: unittests
Could not find executable /home/lola/Workspace/Zondax/ledger-oasis/build/unittests
Looked in the following places:
/home/lola/Workspace/Zondax/ledger-oasis/build/unittests
/home/lola/Workspace/Zondax/ledger-oasis/build/unittests
...
```

The executable was actually in a `bin` folder the `build` folder. I got it working by updating it the path in the Cmake file.

However it is not clear for me why the circle CI build is still working ? Not sure why it only affected me.